### PR TITLE
👷 Add reencoding github action for publish

### DIFF
--- a/.github/actions/reencode-dictionaries/action.yml
+++ b/.github/actions/reencode-dictionaries/action.yml
@@ -1,0 +1,5 @@
+name: 'run rencode dictionaries'
+description: 'Changes the dictionaries encoding to UTF-8'
+runs:
+  using: 'node16'
+  main: 'index.js'

--- a/.github/actions/reencode-dictionaries/index.js
+++ b/.github/actions/reencode-dictionaries/index.js
@@ -1,0 +1,132 @@
+
+const core = require('@actions/core');
+const fs = require('fs');
+const path = require('path');
+const Iconv = require('iconv').Iconv;
+
+const rootPath = path.resolve(__dirname, '../../../')
+const buildPath = path.resolve(rootPath, 'build')
+
+function run() {
+  try {
+    getDictionariesFolders(rootPath).map(({ path, dictFolderName }) => {
+      return {
+        dictFolderName,
+        dictionaries: getAffixDicPairs(path)
+      }
+    })
+      .filter(r => r.dictionaries.length)
+      .forEach(processDictionaryFoler)
+
+  } catch (error) {
+    console.log(error)
+    core.setFailed(error.message);
+  }
+}
+
+function getDictionariesFolders(basePath) {
+  return fs.readdirSync(basePath, { withFileTypes: true })
+    .filter(dirent => dirent.isDirectory())
+    .filter(dirent => !dirent.name.startsWith('.'))
+    .filter(dirent => {
+      const subFolderPath = path.resolve(basePath, dirent.name);
+      return !!fs.readdirSync(subFolderPath, { withFileTypes: true })
+        .find(
+          dirent => dirent.isFile() && (
+            dirent.name.endsWith('.aff') ||
+            dirent.name.endsWith('.dic')
+          )
+        )
+    })
+    .map(dirent => ({
+      path: path.resolve(basePath, dirent.name),
+      dictFolderName: dirent.name
+    }))
+}
+
+
+function getAffixDicPairs(folder) {
+  return fs.readdirSync(folder, { withFileTypes: true })
+    .filter(dirent => dirent.name.endsWith('.aff'))
+    .map(dirent => {
+      const aff = {
+        path: path.resolve(folder, dirent.name),
+        name: dirent.name
+      }
+
+      const dicFilename = `${path.parse(aff.name).name}.dic`;
+
+      const dic = {
+        path: path.resolve(folder, dicFilename),
+        name: dicFilename,
+      }
+      return {
+        aff,
+        dic
+      }
+    })
+    .filter(({ dic }) => fs.existsSync(dic.path))
+}
+
+function processDictionaryFoler(dictionaryFolder) {
+  const resultFolderPath = createResultDictionaryFolder(dictionaryFolder.dictFolderName)
+
+  dictionaryFolder.dictionaries.forEach(({ aff, dic }) => {
+    const encoding = getEncoding(aff.path);
+    let isUtf8 = encoding === 'UTF-8'
+    let affContent;
+    let dicContent;
+    if (isUtf8) {
+      affContent = fs.readFileSync(aff.path)
+      dicContent = fs.readFileSync(dic.path)
+    } else {
+      console.log('Found', encoding, 'aff file', aff.path, 'converting to UTF-8')
+      const iconv = new Iconv(encoding, 'UTF-8');
+      affContent = iconv.convert(
+        fs.readFileSync(aff.path)
+      )
+
+      dicContent = iconv.convert(
+        fs.readFileSync(dic.path)
+      )
+    }
+
+    const resultAffFilePath = path.resolve(resultFolderPath, aff.name)
+    const resultDicFilePAth = path.resolve(resultFolderPath, dic.name)
+
+    fs.writeFileSync(resultAffFilePath, affContent)
+    fs.writeFileSync(resultDicFilePAth, dicContent)
+
+    if (!isUtf8) {
+      changeAffFileEncodingSettingToUtf8(resultAffFilePath)
+    }
+  })
+}
+
+function createResultDictionaryFolder(dictionaryFolderName) {
+  const dictFolderPath = path.resolve(buildPath, dictionaryFolderName)
+  fs.mkdirSync(
+    dictFolderPath,
+    { recursive: true }
+  )
+
+  return dictFolderPath;
+}
+const encodingRegex = /SET\s\S*\s*$/gm
+
+function getEncoding(affFilePath) {
+  const fileData = fs.readFileSync(affFilePath, 'utf8');
+  let encodingLine = fileData.match(encodingRegex)[0]
+  return encodingLine
+    .replace(/\s/g, '')
+    .substring(3)
+    .toUpperCase();
+}
+
+function changeAffFileEncodingSettingToUtf8(affFilePath) {
+  let fileData = fs.readFileSync(affFilePath, 'utf8');
+  fileData = fileData.replace(encodingRegex, 'SET UTF-8\n');
+  fs.writeFileSync(affFilePath, fileData, { encoding: 'utf8' })
+}
+
+run();

--- a/.github/actions/reencode-dictionaries/package-lock.json
+++ b/.github/actions/reencode-dictionaries/package-lock.json
@@ -1,0 +1,205 @@
+{
+  "name": "reencode-dictionaries",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@actions/core": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.9.0.tgz",
+      "integrity": "sha512-5pbM693Ih59ZdUhgk+fts+bUWTnIdHV3kwOSr+QIoFHMLg7Gzhwm0cifDY/AG68ekEJAkHnQVpcy4f6GjmzBCA==",
+      "requires": {
+        "@actions/http-client": "^2.0.1"
+      }
+    },
+    "@actions/github": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@actions/github/-/github-5.0.3.tgz",
+      "integrity": "sha512-myjA/pdLQfhUGLtRZC/J4L1RXOG4o6aYdiEq+zr5wVVKljzbFld+xv10k1FX6IkIJtNxbAq44BdwSNpQ015P0A==",
+      "requires": {
+        "@actions/http-client": "^2.0.1",
+        "@octokit/core": "^3.6.0",
+        "@octokit/plugin-paginate-rest": "^2.17.0",
+        "@octokit/plugin-rest-endpoint-methods": "^5.13.0"
+      }
+    },
+    "@actions/http-client": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.0.1.tgz",
+      "integrity": "sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==",
+      "requires": {
+        "tunnel": "^0.0.6"
+      }
+    },
+    "@octokit/auth-token": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
+      "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
+      "requires": {
+        "@octokit/types": "^6.0.3"
+      }
+    },
+    "@octokit/core": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
+      "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
+      "requires": {
+        "@octokit/auth-token": "^2.4.4",
+        "@octokit/graphql": "^4.5.8",
+        "@octokit/request": "^5.6.3",
+        "@octokit/request-error": "^2.0.5",
+        "@octokit/types": "^6.0.3",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/endpoint": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
+      "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
+      "requires": {
+        "@octokit/types": "^6.0.3",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/graphql": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
+      "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
+      "requires": {
+        "@octokit/request": "^5.6.0",
+        "@octokit/types": "^6.0.3",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/openapi-types": {
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.11.0.tgz",
+      "integrity": "sha512-VsXyi8peyRq9PqIz/tpqiL2w3w80OgVMwBHltTml3LmVvXiphgeqmY9mvBw9Wu7e0QWk/fqD37ux8yP5uVekyQ=="
+    },
+    "@octokit/plugin-paginate-rest": {
+      "version": "2.21.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.21.3.tgz",
+      "integrity": "sha512-aCZTEf0y2h3OLbrgKkrfFdjRL6eSOo8komneVQJnYecAxIej7Bafor2xhuDJOIFau4pk0i/P28/XgtbyPF0ZHw==",
+      "requires": {
+        "@octokit/types": "^6.40.0"
+      }
+    },
+    "@octokit/plugin-rest-endpoint-methods": {
+      "version": "5.16.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.16.2.tgz",
+      "integrity": "sha512-8QFz29Fg5jDuTPXVtey05BLm7OB+M8fnvE64RNegzX7U+5NUXcOcnpTIK0YfSHBg8gYd0oxIq3IZTe9SfPZiRw==",
+      "requires": {
+        "@octokit/types": "^6.39.0",
+        "deprecation": "^2.3.1"
+      }
+    },
+    "@octokit/request": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
+      "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
+      "requires": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.1.0",
+        "@octokit/types": "^6.16.1",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/request-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
+      "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
+      "requires": {
+        "@octokit/types": "^6.0.3",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "@octokit/types": {
+      "version": "6.41.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.41.0.tgz",
+      "integrity": "sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==",
+      "requires": {
+        "@octokit/openapi-types": "^12.11.0"
+      }
+    },
+    "@vercel/ncc": {
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.33.4.tgz",
+      "integrity": "sha512-ln18hs7dMffelP47tpkaR+V5Tj6coykNyxJrlcmCormPqRQjB/Gv4cu2FfBG+PMzIfdZp2CLDsrrB1NPU22Qhg=="
+    },
+    "before-after-hook": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
+      "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ=="
+    },
+    "deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+    },
+    "iconv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/iconv/-/iconv-3.0.1.tgz",
+      "integrity": "sha512-lJnFLxVc0d82R7GfU7a9RujKVUQ3Eee19tPKWZWBJtAEGRHVEyFzCtbNl3GPKuDnHBBRT4/nDS4Ru9AIDT72qA=="
+    },
+    "is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
+    },
+    "node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
+    },
+    "universal-user-agent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    }
+  }
+}

--- a/.github/actions/reencode-dictionaries/package.json
+++ b/.github/actions/reencode-dictionaries/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "reencode-dictionaries",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "build": "ncc build src/index.js -o ."
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@actions/core": "^1.6.0",
+    "@actions/github": "^5.0.0",
+    "@vercel/ncc": "^0.33.4",
+    "iconv": "^3.0.1"
+  }
+}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,10 @@ jobs:
       with:
         node-version: '14.x'
         registry-url: 'https://npm.pkg.github.com'
+    - name: Build reencode action
+      run: cd ./.github/actions/reencode-dictionaries && npm install && cd ../../../
+    - name: "Change dictionaries encoding to UTF-8"
+      uses: ./.github/actions/reencode-dictionaries
     - name: Publish
       run: npm publish
       env:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build
+.github/actions/reencode-dictionaries/node_modules

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/dictionaries",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "scripts": {
   },
   "repository": {


### PR DESCRIPTION
We should actually reencode the dictionaries to the UTF-8 encoding as
there is [issue](https://github.com/kwonoj/hunspell-asm#things-to-note) with the `hunspell-asm` package which only allows to use
the UTF-8 encoded dictionaries otherwise it returns garbage

BREAKING CHANGE
---
The breaking change is that now the dictionaries should be loaded from
the build folder