### PR TITLE
🐛 Missing build folder in the published package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,1 @@
-build
 node_modules

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/dictionaries",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "scripts": {
   },
   "repository": {


### PR DESCRIPTION
The folder is missing, because npm by default uses the .gitignore file which ignores the build folder