### PR TITLE
🔖 Bump version to 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/dictionaries",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "scripts": {
   },
   "repository": {


### PR DESCRIPTION
Allows us to tag a release which includes the new `*_reedsy.dic` files