### PR TITLE
👷 Bump checkout and setup-node to v6

### DIFF
--- a/.github/workflows/process-queue-ci.yml
+++ b/.github/workflows/process-queue-ci.yml
@@ -15,8 +15,8 @@ jobs:
       run:
         working-directory: ./scripts/process-queue
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version-file: './scripts/process-queue/.nvmrc'
           registry-url: 'https://npm.pkg.github.com'

--- a/.github/workflows/process-queue.yml
+++ b/.github/workflows/process-queue.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v3
@@ -50,7 +50,7 @@ jobs:
           gsutil -m cp "gs://production-reedsy-editor-auxiliary/dictionaries/${{ matrix.dictionary }}/*.json" "./queue/${{ matrix.dictionary }}/" || true
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: './scripts/process-queue/.nvmrc'
           registry-url: 'https://npm.pkg.github.com'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v6
+    - uses: actions/setup-node@v6
       with:
         node-version-file: '.nvmrc'
         registry-url: 'https://npm.pkg.github.com'


### PR DESCRIPTION
`setup-node@v4` uses Node 20 which is deprecated and will be removed from the runner on 16th September.

Node 20 itself went EOL in April.

Our code already runs Node 24 since we specify `node-version-file` as an arg to `setup-node`. This is just for the runner which runs the workflows itself.