### PR TITLE
🔧 Exclude `@reedsy/*` from `min-release-age`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
 @reedsy:registry=https://npm.pkg.github.com
 min-release-age=7
+min-release-age-exclude[]=@reedsy/*
 engine-strict=true


### PR DESCRIPTION
See https://github.com/reedsy/reedsy-editor/issues/14160

Two weeks ago, Dependabot [started honouring][1] the `min-release-age` setting in our `.npmrc`. While this is desirable for external dependencies, it means we now have to wait a week before bumps to our own `@reedsy/*` packages can land — even though we already trust them.

`npm@11.17.0` [added support][2] for a new `min-release-age-exclude` setting, which lets us exempt specific scopes from the age restriction.

This change adds `@reedsy/*` to the exclusion list, which restores immediate local installability for our own packages. Once Dependabot picks up the new setting, automatic bumps for `@reedsy/*` will resume too.

[1]: https://github.com/dependabot/dependabot-core/pull/15132
[2]: https://github.com/npm/cli/pull/9532

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
